### PR TITLE
Extended Base Hash

### DIFF
--- a/src/eg/src/ballot.rs
+++ b/src/eg/src/ballot.rs
@@ -320,11 +320,8 @@ mod test {
 
         let hashes = Hashes::compute(&election_parameters, &election_manifest).unwrap();
 
-        let hashes_ext = HashesExt::compute(
-            &election_parameters,
-            &hashes,
-            &joint_election_public_key,
-        );
+        let hashes_ext =
+            HashesExt::compute(&election_parameters, &hashes, &joint_election_public_key);
 
         let pre_voting_data = PreVotingData {
             manifest: election_manifest,
@@ -595,7 +592,6 @@ mod test {
             &election_parameters,
             &hashes,
             &joint_election_public_key,
-            guardian_public_keys.as_slice(),
         );
 
         let pre_voting_data = PreVotingData {

--- a/src/eg/src/election_record.rs
+++ b/src/eg/src/election_record.rs
@@ -85,12 +85,7 @@ impl PreVotingData {
         let hashes = Hashes::compute(&parameters, &manifest)
             .context("Could not compute hashes from election context")?;
 
-        let hashes_ext = HashesExt::compute(
-            &parameters,
-            &hashes,
-            &joint_election_public_key,
-            guardian_public_keys,
-        );
+        let hashes_ext = HashesExt::compute(&parameters, &hashes, &joint_election_public_key);
 
         let pre_voting_data = PreVotingData::new(
             manifest,

--- a/src/eg/src/hashes.rs
+++ b/src/eg/src/hashes.rs
@@ -162,9 +162,10 @@ mod test {
     use crate::{
         ballot_style::BallotStyle,
         election_manifest::{Contest, ContestIndex, ContestOption},
+        example_election_parameters::example_election_parameters,
         guardian::GuardianIndex,
         standard_parameters::STANDARD_PARAMETERS,
-        varying_parameters::{BallotChaining, VaryingParameters}, example_election_parameters::example_election_parameters,
+        varying_parameters::{BallotChaining, VaryingParameters},
     };
     use hex_literal::hex;
 

--- a/src/eg/src/hashes_ext.rs
+++ b/src/eg/src/hashes_ext.rs
@@ -22,7 +22,6 @@ pub struct HashesExt {
 }
 
 impl HashesExt {
-
     /// This function computes the extended base hash
     pub fn compute(
         election_parameters: &ElectionParameters,
@@ -32,7 +31,7 @@ impl HashesExt {
         let fixed_parameters = &election_parameters.fixed_parameters;
         // Computation of the extended base hash H_E.
         let h_e = {
-            // B1 = 12 | b(K, 512) 
+            // B1 = 12 | b(K, 512)
             let mut v = vec![0x12];
             // K = election public key
             v.append(&mut joint_election_public_key.to_be_bytes_left_pad(fixed_parameters));
@@ -72,7 +71,6 @@ impl HashesExt {
         serde_json::from_reader(io_read)
             .map_err(|e| anyhow!("Error parsing JointElectionPublicKey: {}", e))
     }
-
 }
 
 impl std::fmt::Display for HashesExt {
@@ -130,11 +128,8 @@ mod test {
             .as_ref()
             .is_valid(&fixed_parameters.group));
 
-        let hashes_ext = HashesExt::compute(
-            &election_parameters,
-            &hashes,
-            &joint_election_public_key,
-        );
+        let hashes_ext =
+            HashesExt::compute(&election_parameters, &hashes, &joint_election_public_key);
 
         let expected_h_e = HValue::from(hex!(
             "84135D7084DC8EC9A6E593EE0D7DF9E8F0444DEEB0B1C72BBCB0184D8D50C3A2"

--- a/src/eg/src/verifiable_decryption.rs
+++ b/src/eg/src/verifiable_decryption.rs
@@ -659,12 +659,7 @@ impl VerifiableDecryption {
             return Err(CombineProofError::JointPKFailure.into());
         };
 
-        let hashes_ext = HashesExt::compute(
-            parameters,
-            &hashes,
-            &joint_election_public_key,
-            guardian_public_keys,
-        );
+        let hashes_ext = HashesExt::compute(parameters, &hashes, &joint_election_public_key);
 
         let proof = DecryptionProof::combine_proof(
             parameters,
@@ -900,7 +895,7 @@ mod test {
         )
         .unwrap();
 
-        let h_e = HashesExt::compute(&election_parameters, &hashes, &joint_key, &public_keys);
+        let h_e = HashesExt::compute(&election_parameters, &hashes, &joint_key);
 
         let message: usize = 42;
         let nonce = field.random_field_elem(&mut csprng);

--- a/src/electionguard/src/subcommands/write_hashes_ext.rs
+++ b/src/electionguard/src/subcommands/write_hashes_ext.rs
@@ -13,10 +13,7 @@ use eg::hashes_ext::HashesExt;
 
 use crate::{
     artifacts_dir::ArtifactFile,
-    common_utils::{
-        load_all_guardian_public_keys, load_election_parameters, load_hashes,
-        load_joint_election_public_key,
-    },
+    common_utils::{load_election_parameters, load_hashes, load_joint_election_public_key},
     subcommand_helper::SubcommandHelper,
     subcommands::Subcommand,
 };
@@ -49,16 +46,8 @@ impl Subcommand for WriteHashesExt {
         let joint_election_public_key =
             load_joint_election_public_key(&subcommand_helper.artifacts_dir, &election_parameters)?;
 
-        //? TODO: Do we need a command line arg to specify all the guardian public key source files?
-        let guardian_public_keys =
-            load_all_guardian_public_keys(&subcommand_helper.artifacts_dir, &election_parameters)?;
-
-        let hashes_ext = HashesExt::compute(
-            &election_parameters,
-            &hashes,
-            &joint_election_public_key,
-            guardian_public_keys.as_slice(),
-        );
+        let hashes_ext =
+            HashesExt::compute(&election_parameters, &hashes, &joint_election_public_key);
 
         let (mut stdiowrite, path) = subcommand_helper
             .artifacts_dir


### PR DESCRIPTION
## Purpose

Adapt the extended base hash to match the EG specification 2.0.0.

## Changes

Remove the guardians' individual public keys from the input for the extended base hash.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.