### PR TITLE
Cleanup of code

### DIFF
--- a/src/eg/Cargo.toml
+++ b/src/eg/Cargo.toml
@@ -18,6 +18,7 @@ static_assertions = "1.1.0"
 thiserror = "1.0"
 util = { path = "../util" }
 base64 = "0.21.2"
+chrono = { version = "0.4.34", features = ["serde"] }
 
 # For testing
 anyhow = "1.0"

--- a/src/eg/src/ballot.rs
+++ b/src/eg/src/ballot.rs
@@ -6,6 +6,7 @@
 #![deny(clippy::manual_assert)]
 
 use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use util::{algebra::FieldElement, csprng::Csprng};
@@ -50,7 +51,7 @@ pub struct BallotEncrypted {
     pub state: BallotState,
 
     /// Date (and time) of ballot generation
-    pub date: String,
+    pub date: DateTime<Utc>,
 
     /// Device that generated this ballot
     pub device: String,
@@ -80,7 +81,7 @@ impl BallotEncrypted {
         contests: &BTreeMap<ContestIndex, ContestEncrypted>,
         state: BallotState,
         confirmation_code: HValue,
-        date: &str,
+        date: DateTime<Utc>,
         device: &str,
     ) -> BallotEncrypted {
         BallotEncrypted {
@@ -88,7 +89,7 @@ impl BallotEncrypted {
             contests: contests.clone(),
             state,
             confirmation_code,
-            date: date.to_string(),
+            date,
             device: device.to_string(),
         }
     }
@@ -124,7 +125,7 @@ impl BallotEncrypted {
             contests,
             state: BallotState::Uncast,
             confirmation_code,
-            date: device.header.parameters.varying_parameters.date.clone(),
+            date: Utc::now(),
             device: device.uuid.clone(),
         })
     }
@@ -137,7 +138,7 @@ impl BallotEncrypted {
         &self.confirmation_code
     }
 
-    pub fn date(&self) -> &String {
+    pub fn date(&self) -> &DateTime<Utc> {
         &self.date
     }
 

--- a/src/eg/src/ballot.rs
+++ b/src/eg/src/ballot.rs
@@ -25,7 +25,6 @@ use crate::{
     joint_election_public_key::Ciphertext,
     zk::ProofRangeError,
 };
-
 use thiserror::Error;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/eg/src/ballot.rs
+++ b/src/eg/src/ballot.rs
@@ -67,7 +67,7 @@ pub struct ScaledBallotEncrypted {
 #[derive(Error, Debug)]
 pub enum BallotEncryptedError {
     /// Proof production error
-    #[error("Error producing ballot proofs: {:?}", err)]
+    #[error("Error producing ballot proofs: {}", err)]
     ProofError { err: ProofRangeError },
     /// Error looking up contest in manifest
     #[error("Contest (index {}) not found in election manifest.", idx)]

--- a/src/eg/src/ballot.rs
+++ b/src/eg/src/ballot.rs
@@ -21,7 +21,8 @@ use crate::{
     election_record::PreVotingData,
     fixed_parameters::FixedParameters,
     hash::HValue,
-    joint_election_public_key::Ciphertext, zk::ProofRangeError,
+    joint_election_public_key::Ciphertext,
+    zk::ProofRangeError,
 };
 
 use thiserror::Error;
@@ -102,15 +103,15 @@ impl BallotEncrypted {
         let mut contests = BTreeMap::new();
 
         for (&c_idx, selection) in ctest_selections {
-            let contest = device.header.manifest.contests.get(c_idx).ok_or(BallotEncryptedError::ContestNotInManifest { idx: c_idx })?;
-            let contest_encrypted = ContestEncrypted::new(
-                device,
-                csprng,
-                primary_nonce,
-                contest,
-                c_idx,
-                selection,
-            ).map_err(|err| BallotEncryptedError::ProofError {err})?;
+            let contest = device
+                .header
+                .manifest
+                .contests
+                .get(c_idx)
+                .ok_or(BallotEncryptedError::ContestNotInManifest { idx: c_idx })?;
+            let contest_encrypted =
+                ContestEncrypted::new(device, csprng, primary_nonce, contest, c_idx, selection)
+                    .map_err(|err| BallotEncryptedError::ProofError { err })?;
 
             contests.insert(c_idx, contest_encrypted);
         }
@@ -267,9 +268,24 @@ mod test {
 
     use super::*;
     use crate::{
-        ballot::BallotEncrypted, ballot_style::BallotStyle, contest_selection::ContestSelection, device::Device, election_manifest::{Contest, ContestOption}, election_record::PreVotingData, example_election_manifest::example_election_manifest, example_election_parameters::example_election_parameters, guardian_public_key::GuardianPublicKey, guardian_secret_key::GuardianSecretKey, guardian_share::{GuardianEncryptedShare, GuardianSecretKeyShare}, hashes::Hashes, hashes_ext::HashesExt, index::Index, joint_election_public_key::JointElectionPublicKey, verifiable_decryption::{
+        ballot::BallotEncrypted,
+        ballot_style::BallotStyle,
+        contest_selection::ContestSelection,
+        device::Device,
+        election_manifest::{Contest, ContestOption},
+        election_record::PreVotingData,
+        example_election_manifest::example_election_manifest,
+        example_election_parameters::example_election_parameters,
+        guardian_public_key::GuardianPublicKey,
+        guardian_secret_key::GuardianSecretKey,
+        guardian_share::{GuardianEncryptedShare, GuardianSecretKeyShare},
+        hashes::Hashes,
+        hashes_ext::HashesExt,
+        index::Index,
+        joint_election_public_key::JointElectionPublicKey,
+        verifiable_decryption::{
             CombinedDecryptionShare, DecryptionProof, DecryptionShare, VerifiableDecryption,
-        }
+        },
     };
     use std::iter::zip;
     use util::csprng::Csprng;
@@ -340,15 +356,15 @@ mod test {
             ),
             (
                 Index::from_one_based_index(3).unwrap(),
-                ContestSelection::new(vec![0, 0, 1]).unwrap()
+                ContestSelection::new(vec![0, 0, 1]).unwrap(),
             ),
             (
                 Index::from_one_based_index(4).unwrap(),
-                ContestSelection::new(vec![1, 0, 0]).unwrap()
+                ContestSelection::new(vec![1, 0, 0]).unwrap(),
             ),
             (
                 Index::from_one_based_index(5).unwrap(),
-                ContestSelection::new(vec![0, 1, 1, 0, 0, 0, 0, 1, 0, 0, 0]).unwrap()
+                ContestSelection::new(vec![0, 1, 1, 0, 0, 0, 0, 1, 0, 0, 0]).unwrap(),
             ),
             (
                 Index::from_one_based_index(6).unwrap(),
@@ -372,13 +388,18 @@ mod test {
             ),
         ]);
 
-        let ballot_from_selections =
-            BallotEncrypted::new_from_selections(Index::from_one_based_index(2).unwrap(), &device, &mut csprng, &primary_nonce, &selections).unwrap();
+        let ballot_from_selections = BallotEncrypted::new_from_selections(
+            Index::from_one_based_index(2).unwrap(),
+            &device,
+            &mut csprng,
+            &primary_nonce,
+            &selections,
+        )
+        .unwrap();
 
         // Let's verify the ballot proofs.
 
-        let verify_result =
-            ballot_from_selections.verify(&device.header);
+        let verify_result = ballot_from_selections.verify(&device.header);
 
         assert!(verify_result)
     }
@@ -575,11 +596,8 @@ mod test {
 
         let hashes = Hashes::compute(&election_parameters, &election_manifest).unwrap();
 
-        let hashes_ext = HashesExt::compute(
-            &election_parameters,
-            &hashes,
-            &joint_election_public_key,
-        );
+        let hashes_ext =
+            HashesExt::compute(&election_parameters, &hashes, &joint_election_public_key);
 
         let pre_voting_data = PreVotingData {
             manifest: election_manifest.clone(),
@@ -630,20 +648,35 @@ mod test {
                 ContestSelection::new(vec![1, 0, 0]).unwrap(),
             ),
         ]);
-        let ballot_voter1 =
-            BallotEncrypted::new_from_selections(Index::from_one_based_index(1).unwrap(), &device, &mut csprng, &primary_nonce, &voter1).unwrap();
-        let verify_result1 =
-            ballot_voter1.verify(&device.header);
+        let ballot_voter1 = BallotEncrypted::new_from_selections(
+            Index::from_one_based_index(1).unwrap(),
+            &device,
+            &mut csprng,
+            &primary_nonce,
+            &voter1,
+        )
+        .unwrap();
+        let verify_result1 = ballot_voter1.verify(&device.header);
         assert!(verify_result1);
-        let ballot_voter2 =
-            BallotEncrypted::new_from_selections(Index::from_one_based_index(2).unwrap(), &device, &mut csprng, &primary_nonce, &voter2).unwrap();
-        let verify_result2 =
-            ballot_voter2.verify(&device.header);
+        let ballot_voter2 = BallotEncrypted::new_from_selections(
+            Index::from_one_based_index(2).unwrap(),
+            &device,
+            &mut csprng,
+            &primary_nonce,
+            &voter2,
+        )
+        .unwrap();
+        let verify_result2 = ballot_voter2.verify(&device.header);
         assert!(verify_result2);
-        let ballot_voter3 =
-            BallotEncrypted::new_from_selections(Index::from_one_based_index(3).unwrap(), &device, &mut csprng, &primary_nonce, &voter3).unwrap();
-        let verify_result3 =
-            ballot_voter3.verify(&device.header);
+        let ballot_voter3 = BallotEncrypted::new_from_selections(
+            Index::from_one_based_index(3).unwrap(),
+            &device,
+            &mut csprng,
+            &primary_nonce,
+            &voter3,
+        )
+        .unwrap();
+        let verify_result3 = ballot_voter3.verify(&device.header);
         assert!(verify_result3);
 
         let factor = FieldElement::from(1u8, &fixed_parameters.field);

--- a/src/eg/src/contest_encrypted.rs
+++ b/src/eg/src/contest_encrypted.rs
@@ -112,13 +112,12 @@ impl ContestEncrypted {
             // This is OK, since selection_and_nonce.len() = pt_vote.vote.len() which
             // is guaranteed to not exceed the size of a `Index<T>` by how a `ContestSelection` is
             // constructed.
-            proof_ballot_correctness
-                .push_unchecked(sel.proof_ballot_correctness(
-                    &device.header,
-                    csprng,
-                    pt_vote.get_vote()[i] == 1u8,
-                    nonce,
-                )?);
+            proof_ballot_correctness.push_unchecked(sel.proof_ballot_correctness(
+                &device.header,
+                csprng,
+                pt_vote.get_vote()[i] == 1u8,
+                nonce,
+            )?);
         }
 
         let mut num_selections = 0;

--- a/src/eg/src/contest_encrypted.rs
+++ b/src/eg/src/contest_encrypted.rs
@@ -20,28 +20,8 @@ use crate::{
     joint_election_public_key::{Ciphertext, Nonce},
     nonce::encrypted as nonce,
     vec1::Vec1,
-    zk::ProofRange,
+    zk::{ProofRange, ProofRangeError},
 };
-
-// /// A contest.
-// #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-// pub struct Contest {
-//     /// The label.
-//     pub label: String,
-
-//     /// The maximum count of options that a voter may select.
-//     pub selection_limit: usize,
-
-//     /// The candidates/options. The order of options matches the virtual ballot.
-//     pub options: Vec<ContestOption>,
-// }
-
-// /// An option in a contest.
-// #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-// pub struct ContestOption {
-//     /// The label.
-//     pub label: String,
-// }
 
 /// A 1-based index of a [`ContestEncrypted`] in the order it is defined in the [`crate::ballot::BallotEncrypted`].
 pub type ContestEncryptedIndex = Index<ContestEncrypted>;
@@ -95,8 +75,8 @@ impl ContestEncrypted {
         // TODO: Check if selection limit is satisfied
 
         let mut vote: Vec<(Ciphertext, Nonce)> = Vec::new();
-        for j in 1..pt_vote.get_vote().len() + 1 {
-            // This unwrap is fine since 1 <= j <= Index::VALID_MAX_U32
+        for j in 1..=pt_vote.get_vote().len() {
+            // This is fine since 1 <= j <= Index::VALID_MAX_U32
             let o_idx = ContestOptionIndex::from_one_based_index_unchecked(j as u32);
             let nonce = nonce(header, primary_nonce, contest_index, o_idx);
             vote.push((
@@ -118,7 +98,7 @@ impl ContestEncrypted {
         contest: &Contest,
         contest_index: ContestIndex,
         pt_vote: &ContestSelection,
-    ) -> ContestEncrypted {
+    ) -> Result<ContestEncrypted, ProofRangeError> {
         let selection_and_nonce =
             Self::encrypt_selection(&device.header, primary_nonce, contest_index, pt_vote);
         let selection = selection_and_nonce
@@ -138,26 +118,24 @@ impl ContestEncrypted {
                     csprng,
                     pt_vote.get_vote()[i] == 1u8,
                     nonce,
-                ));
+                )?);
         }
 
         let mut num_selections = 0;
         pt_vote.get_vote().iter().for_each(|v| num_selections += v);
-
         let proof_selection_limit = ContestEncrypted::proof_selection_limit(
             &device.header,
             csprng,
             &selection_and_nonce,
             num_selections as usize,
             contest.selection_limit,
-        );
-
-        ContestEncrypted {
+        )?;
+        Ok(ContestEncrypted {
             selection,
             contest_hash,
             proof_ballot_correctness,
             proof_selection_limit,
-        }
+        })
     }
 
     pub fn get_proof_ballot_correctness(&self) -> &Vec1<ProofRange> {
@@ -174,7 +152,7 @@ impl ContestEncrypted {
         selection: &[(Ciphertext, Nonce)],
         num_selections: usize,
         selection_limit: usize,
-    ) -> ProofRange {
+    ) -> Result<ProofRange, ProofRangeError> {
         let (combined_ct, combined_nonce) =
             Self::sum_selection_nonce_vector(&header.parameters.fixed_parameters, selection);
         ProofRange::new(

--- a/src/eg/src/contest_selection.rs
+++ b/src/eg/src/contest_selection.rs
@@ -18,16 +18,6 @@ use crate::{
     zk::{ProofRange, ProofRangeError},
 };
 
-// An encrypted option in a contest.
-// #[derive(Debug, Clone)]
-// pub struct ContestSelectionCiphertext {
-//     /// Ciphertext
-//     pub ciphertext: Ciphertext,
-//     // TODO: Probably shouldn't be here
-//     // Nonce used to produce the ciphertext
-//     // pub nonce: BigUint,
-// }
-
 pub type ContestSelectionPlaintext = u8;
 
 // /// A 1-based index of a [`ContestSelectionPlaintext`] in the order it is defined in the [`crate::election_manifest::ElectionManifest`].
@@ -81,21 +71,6 @@ impl ContestSelection {
 
         Self { vote }
     }
-
-    // Choices are 1-indexed
-    // pub fn new_unchecked(choices: Vec<u32>, num_options: usize) -> Self {
-    //     let mut vote = Vec::new();
-    //     for _ in 0..num_options {
-    //         vote.try_push(0).unwrap();
-    //     }
-
-    //     for choice in choices {
-    //         let idx = <Index<u8>>::from_one_based_index(choice).unwrap();
-    //         *vote.get_mut(idx).unwrap() = 1u8;
-    //     }
-
-    //     Self { vote }
-    // }
 }
 
 impl Ciphertext {
@@ -114,28 +89,3 @@ impl Ciphertext {
         proof.verify(header, self, 1)
     }
 }
-
-// /// Serialize for CiphertextContestSelection
-// impl Serialize for ContestSelectionCiphertext {
-//     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-//     where
-//         S: serde::ser::Serializer,
-//     {
-//         self.ciphertext.clone().serialize(serializer)
-//     }
-// }
-
-// impl<'de> Deserialize<'de> for ContestSelectionCiphertext {
-//     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-//     where
-//         D: serde::Deserializer<'de>,
-//     {
-//         match Ciphertext::deserialize(deserializer) {
-//             Ok(ciphertext) => Ok(ContestSelectionCiphertext {
-//                 ciphertext,
-//                 nonce: BigUint::from(0 as u8),
-//             }),
-//             Err(e) => Err(e),
-//         }
-//     }
-// }

--- a/src/eg/src/contest_selection.rs
+++ b/src/eg/src/contest_selection.rs
@@ -40,7 +40,7 @@ pub type ContestSelectionIndex = Index<ContestSelection>;
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ContestSelection {
     /// Vector used to represent the selection
-    pub vote: Vec<ContestSelectionPlaintext>,
+    vote: Vec<ContestSelectionPlaintext>,
 }
 
 impl HasIndexType for ContestSelection {
@@ -48,6 +48,17 @@ impl HasIndexType for ContestSelection {
 }
 
 impl ContestSelection {
+    pub fn new(vote: Vec<ContestSelectionPlaintext>) -> Option<ContestSelection>{
+        if vote.len() > Index::<ContestSelectionPlaintext>::VALID_MAX_USIZE {
+            return None;
+        }
+        Some(ContestSelection{vote})
+    }
+
+    pub fn get_vote(&self) -> &[ContestSelectionPlaintext]{
+        &self.vote
+    }
+
     pub fn new_pick_random(
         csprng: &mut Csprng,
         selection_limit: usize,

--- a/src/eg/src/contest_selection.rs
+++ b/src/eg/src/contest_selection.rs
@@ -20,9 +20,6 @@ use crate::{
 
 pub type ContestSelectionPlaintext = u8;
 
-// /// A 1-based index of a [`ContestSelectionPlaintext`] in the order it is defined in the [`crate::election_manifest::ElectionManifest`].
-// pub type ContestSelectionPlaintextIndex = Index<ContestSelectionPlaintext>;
-
 /// A 1-based index of a [`ContestSelection`].
 pub type ContestSelectionIndex = Index<ContestSelection>;
 

--- a/src/eg/src/contest_selection.rs
+++ b/src/eg/src/contest_selection.rs
@@ -48,14 +48,14 @@ impl HasIndexType for ContestSelection {
 }
 
 impl ContestSelection {
-    pub fn new(vote: Vec<ContestSelectionPlaintext>) -> Option<ContestSelection>{
+    pub fn new(vote: Vec<ContestSelectionPlaintext>) -> Option<ContestSelection> {
         if vote.len() > Index::<ContestSelectionPlaintext>::VALID_MAX_USIZE {
             return None;
         }
-        Some(ContestSelection{vote})
+        Some(ContestSelection { vote })
     }
 
-    pub fn get_vote(&self) -> &[ContestSelectionPlaintext]{
+    pub fn get_vote(&self) -> &[ContestSelectionPlaintext] {
         &self.vote
     }
 

--- a/src/eg/src/contest_selection.rs
+++ b/src/eg/src/contest_selection.rs
@@ -15,7 +15,7 @@ use crate::{
     index::Index,
     joint_election_public_key::{Ciphertext, Nonce},
     vec1::HasIndexType,
-    zk::ProofRange,
+    zk::{ProofRange, ProofRangeError},
 };
 
 // An encrypted option in a contest.
@@ -105,7 +105,7 @@ impl Ciphertext {
         csprng: &mut Csprng,
         selected: bool,
         nonce: &Nonce,
-    ) -> ProofRange {
+    ) -> Result<ProofRange, ProofRangeError> {
         ProofRange::new(header, csprng, self, nonce, selected as usize, 1)
     }
 

--- a/src/eg/src/election_record.rs
+++ b/src/eg/src/election_record.rs
@@ -41,36 +41,35 @@ pub struct PreVotingData {
     pub public_key: JointElectionPublicKey,
 }
 
-#[allow(dead_code)]
 /// The body of the election record, generated after the election is complete.
 #[derive(Debug)]
 pub struct ElectionRecordBody {
     /// Guardian public keys including commitments and proofs of knowledge
-    guardian_public_keys: Vec<GuardianPublicKey>,
+    pub guardian_public_keys: Vec<GuardianPublicKey>,
 
     /// Every encrypted ballot prepared in the election (whether cast or challenged) together
     /// with its weight used in the tally.
-    all_ballots: Vec<(BallotEncrypted, FieldElement)>,
+    pub all_ballots: Vec<(BallotEncrypted, FieldElement)>,
 
     /// Encrypted tallies of each option
-    encrypted_tallies: BTreeMap<ContestIndex, Vec<Ciphertext>>,
+    pub encrypted_tallies: BTreeMap<ContestIndex, Vec<Ciphertext>>,
 
     /// Decrypted tallies with proofs of correct decryption
-    decrypted_tallies: BTreeMap<ContestIndex, Vec<VerifiableDecryption>>,
+    pub decrypted_tallies: BTreeMap<ContestIndex, Vec<VerifiableDecryption>>,
 
     /// Every challenged ballot
     // challenged_ballots: Vec<BallotSelections>,
 
     /// Ordered lists of ballots encrypted by each device. The values are indiced of the `all_ballots`
     /// vector.
-    ballots_by_device: HashMap<String, usize>,
+    pub ballots_by_device: HashMap<String, usize>,
 }
-#[allow(dead_code)]
+
 /// The election record.
 #[derive(Debug)]
 pub struct ElectionRecord {
-    prevoting: PreVotingData,
-    body: ElectionRecordBody,
+    pub prevoting: PreVotingData,
+    pub body: ElectionRecordBody,
 }
 
 impl PreVotingData {

--- a/src/eg/src/election_record.rs
+++ b/src/eg/src/election_record.rs
@@ -61,8 +61,9 @@ pub struct ElectionRecordBody {
     /// Every challenged ballot
     // challenged_ballots: Vec<BallotSelections>,
 
-    /// Ordered lists of ballots encrypted by each device
-    ballots_by_device: HashMap<String, String>,
+    /// Ordered lists of ballots encrypted by each device. The values are indiced of the `all_ballots`
+    /// vector.
+    ballots_by_device: HashMap<String, usize>,
 }
 #[allow(dead_code)]
 /// The election record.

--- a/src/eg/src/example_election_parameters.rs
+++ b/src/eg/src/example_election_parameters.rs
@@ -5,7 +5,6 @@
 #![deny(clippy::panic)]
 #![deny(clippy::manual_assert)]
 
-use chrono::{TimeZone, Utc};
 use crate::{
     election_parameters::ElectionParameters,
     fixed_parameters::FixedParameters,
@@ -13,6 +12,7 @@ use crate::{
     standard_parameters::STANDARD_PARAMETERS,
     varying_parameters::{BallotChaining, VaryingParameters},
 };
+use chrono::{TimeZone, Utc};
 
 /// An example ElectionParameters object, based on the standard parameters.
 pub fn example_election_parameters() -> ElectionParameters {

--- a/src/eg/src/example_election_parameters.rs
+++ b/src/eg/src/example_election_parameters.rs
@@ -5,6 +5,8 @@
 #![deny(clippy::panic)]
 #![deny(clippy::manual_assert)]
 
+use chrono::{TimeZone, Utc};
+
 use crate::{
     election_parameters::ElectionParameters,
     fixed_parameters::FixedParameters,
@@ -29,7 +31,7 @@ pub fn example_election_parameters() -> ElectionParameters {
     let varying_parameters = VaryingParameters {
         n,
         k,
-        date: "2023-05-02".to_string(),
+        date: Utc.with_ymd_and_hms(2023, 05, 02, 0, 0, 0).unwrap(),
         info: "The United Realms of Imaginaria, General Election".to_string(),
         ballot_chaining: BallotChaining::Prohibited,
     };

--- a/src/eg/src/example_election_parameters.rs
+++ b/src/eg/src/example_election_parameters.rs
@@ -6,7 +6,6 @@
 #![deny(clippy::manual_assert)]
 
 use chrono::{TimeZone, Utc};
-
 use crate::{
     election_parameters::ElectionParameters,
     fixed_parameters::FixedParameters,

--- a/src/eg/src/example_election_parameters.rs
+++ b/src/eg/src/example_election_parameters.rs
@@ -31,7 +31,7 @@ pub fn example_election_parameters() -> ElectionParameters {
     let varying_parameters = VaryingParameters {
         n,
         k,
-        date: Utc.with_ymd_and_hms(2023, 05, 02, 0, 0, 0).unwrap(),
+        date: Utc.with_ymd_and_hms(2023, 5, 2, 0, 0, 0).unwrap(),
         info: "The United Realms of Imaginaria, General Election".to_string(),
         ballot_chaining: BallotChaining::Prohibited,
     };

--- a/src/eg/src/guardian_share.rs
+++ b/src/eg/src/guardian_share.rs
@@ -119,7 +119,7 @@ impl GuardianEncryptedShare {
     fn mac_and_encryption_key(i: u32, l: u32, k_i_l: &HValue) -> (HValue, HValue) {
         // label = b("share_enc_keys",14)
         let label = "share_enc_keys".as_bytes();
-        // context = share_enc_keys("share_encrypt",13) | b(i, 4) | b(l, 4)
+        // context = b("share_encrypt",13) | b(i, 4) | b(l, 4)
         let mut context = "share_encrypt".as_bytes().to_vec();
         context.extend_from_slice(i.to_be_bytes().as_slice());
         context.extend_from_slice(l.to_be_bytes().as_slice());

--- a/src/eg/src/hashes.rs
+++ b/src/eg/src/hashes.rs
@@ -87,7 +87,7 @@ impl Hashes {
             }
 
             for u in [
-                &election_parameters.varying_parameters.date,
+                &election_parameters.varying_parameters.date.to_rfc3339(),
                 &election_parameters.varying_parameters.info,
             ] {
                 v.extend_from_slice(u.as_bytes());
@@ -167,6 +167,7 @@ mod test {
         standard_parameters::STANDARD_PARAMETERS,
         varying_parameters::{BallotChaining, VaryingParameters},
     };
+    use chrono::{TimeZone, Utc};
     use hex_literal::hex;
 
     #[test]
@@ -230,7 +231,7 @@ mod test {
         let varying_parameters = VaryingParameters {
             n,
             k,
-            date: "1212-12-12".to_string(),
+            date: Utc.with_ymd_and_hms(1212, 12, 12, 0, 0, 0).unwrap(),
             info: "Testing".to_string(),
             ballot_chaining: BallotChaining::Prohibited,
         };
@@ -255,7 +256,7 @@ mod test {
             "242568E9ECD120DA2CD7C86FB7F8504996FBAE934A558CF28D22DC8529C7C487"
         ));
         let expected_h_b = HValue::from(hex!(
-            "9D9A936241784D8D0B926579B6A7E7036AC2DE91B0EAC48ACC157A75EB179A79"
+            "ECF3D1424BAC568DEB036005E4151C8CE888913A291A6AA2C307BCE091EB48CB"
         ));
 
         #[cfg(test_hash_mismatch_warn_only)]

--- a/src/eg/src/hashes.rs
+++ b/src/eg/src/hashes.rs
@@ -252,6 +252,8 @@ mod test {
         let expected_h_p = HValue::from(hex!(
             "2B3B025E50E09C119CBA7E9448ACD1CABC9447EF39BF06327D81C665CDD86296"
         ));
+        // These hashes are to get notified if the hash computation is changed. They have
+        // not been computed externally.
         let expected_h_m = HValue::from(hex!(
             "242568E9ECD120DA2CD7C86FB7F8504996FBAE934A558CF28D22DC8529C7C487"
         ));

--- a/src/eg/src/hashes_ext.rs
+++ b/src/eg/src/hashes_ext.rs
@@ -132,7 +132,7 @@ mod test {
             HashesExt::compute(&election_parameters, &hashes, &joint_election_public_key);
 
         let expected_h_e = HValue::from(hex!(
-            "84135D7084DC8EC9A6E593EE0D7DF9E8F0444DEEB0B1C72BBCB0184D8D50C3A2"
+            "5BFE1B5789C2F0D3C3C16D5D0F43012B5F920CC0AA61FF92B4B04C759B472F82"
         ));
 
         #[cfg(test_hash_mismatch_warn_only)]

--- a/src/eg/src/index.rs
+++ b/src/eg/src/index.rs
@@ -144,6 +144,12 @@ impl<T> Index<T> {
             .ok_or_else(|| anyhow!("Index value {ix1} out of range"))
     }
 
+    /// Creates a new `Index` from a 1-based index value. It is a precondition that
+    /// Self::VALID_MIN_U32 <= ix1 && ix1 <= Self::VALID_MAX_U32.
+    pub fn from_one_based_index_unchecked(ix1: u32) -> Self {
+        Self(ix1, PhantomData)
+    }
+
     /// Obtains the 1-based index value as a `u32`.
     pub const fn get_one_based_u32(&self) -> u32 {
         debug_assert!(Self::is_valid_one_based_index(self.0));

--- a/src/eg/src/varying_parameters.rs
+++ b/src/eg/src/varying_parameters.rs
@@ -6,6 +6,7 @@
 #![deny(clippy::manual_assert)]
 
 use anyhow::{ensure, Result};
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::guardian::GuardianIndex;
@@ -28,7 +29,7 @@ pub struct VaryingParameters {
     pub k: GuardianIndex,
 
     /// Date string.
-    pub date: String,
+    pub date: DateTime<Utc>,
 
     /// Jurisdictional information string. This can be used to specify a location.
     pub info: String,

--- a/src/eg/src/varying_parameters.rs
+++ b/src/eg/src/varying_parameters.rs
@@ -30,7 +30,7 @@ pub struct VaryingParameters {
     /// Date string.
     pub date: String,
 
-    // Jurisdictional information string.
+    /// Jurisdictional information string. This can be used to specify a location.
     pub info: String,
 
     /// Ballot chaining.

--- a/src/eg/src/vec1.rs
+++ b/src/eg/src/vec1.rs
@@ -104,7 +104,6 @@ impl<T: HasIndexType> Vec1<T> {
         self.0.push(value);
     }
 
-
     /// Attempts to reserve capacity for at least the specified number of additional elements to be
     /// added. Compare to: [`Vec::try_reserve`].
     pub fn try_reserve(&mut self, additional: usize) -> Result<(), TryReserveError> {

--- a/src/eg/src/vec1.rs
+++ b/src/eg/src/vec1.rs
@@ -98,7 +98,7 @@ impl<T: HasIndexType> Vec1<T> {
         Ok(())
     }
 
-    /// Pushes an additional element onto the Vec1. It is a precondition that doing so would exceed
+    /// Pushes an additional element onto the Vec1. It is a precondition that doing so would not exceed
     /// the size of a `Index<T>`.
     pub fn push_unchecked(&mut self, value: T) {
         self.0.push(value);

--- a/src/eg/src/vec1.rs
+++ b/src/eg/src/vec1.rs
@@ -98,6 +98,13 @@ impl<T: HasIndexType> Vec1<T> {
         Ok(())
     }
 
+    /// Pushes an additional element onto the Vec1. It is a precondition that doing so would exceed
+    /// the size of a `Index<T>`.
+    pub fn push_unchecked(&mut self, value: T) {
+        self.0.push(value);
+    }
+
+
     /// Attempts to reserve capacity for at least the specified number of additional elements to be
     /// added. Compare to: [`Vec::try_reserve`].
     pub fn try_reserve(&mut self, additional: usize) -> Result<(), TryReserveError> {

--- a/src/eg/src/verifiable_decryption.rs
+++ b/src/eg/src/verifiable_decryption.rs
@@ -796,7 +796,7 @@ mod test {
         let varying_parameters = VaryingParameters {
             n: GuardianIndex::from_one_based_index(3).unwrap(),
             k: GuardianIndex::from_one_based_index(3).unwrap(),
-            date: Utc.with_ymd_and_hms(2023, 05, 02, 0, 0, 0).unwrap(),
+            date: Utc.with_ymd_and_hms(2023, 5, 2, 0, 0, 0).unwrap(),
             info: "The test election".to_string(),
             ballot_chaining: BallotChaining::Prohibited,
         };

--- a/src/eg/src/verifiable_decryption.rs
+++ b/src/eg/src/verifiable_decryption.rs
@@ -562,6 +562,7 @@ pub enum DecryptionError {
 /// Represents a "in-the-exponent" plain-text with a [`DecryptionProof`].
 ///
 /// This corresponds to `t` and `(c,v)` as in Section `3.6.3`.
+#[derive(Debug)]
 pub struct VerifiableDecryption {
     /// The decrypted plain-text
     pub plain_text: FieldElement,
@@ -718,6 +719,7 @@ impl VerifiableDecryption {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod test {
+    use chrono::{TimeZone, Utc};
     use std::iter::zip;
     use util::{algebra::FieldElement, csprng::Csprng};
 
@@ -794,7 +796,7 @@ mod test {
         let varying_parameters = VaryingParameters {
             n: GuardianIndex::from_one_based_index(3).unwrap(),
             k: GuardianIndex::from_one_based_index(3).unwrap(),
-            date: "2023-05-02".to_string(),
+            date: Utc.with_ymd_and_hms(2023, 05, 02, 0, 0, 0).unwrap(),
             info: "The test election".to_string(),
             ballot_chaining: BallotChaining::Prohibited,
         };

--- a/src/eg/src/zk.rs
+++ b/src/eg/src/zk.rs
@@ -42,7 +42,9 @@ impl HasIndexTypeMarker for ProofRange {}
 #[derive(Error, Debug)]
 pub enum ProofRangeError {
     /// Bla bla
-    #[error("It must be the case that 0 ≤ small_l ≤ big_l (here small_l={small_l} and big_l={big_l}).")]
+    #[error(
+        "It must be the case that 0 ≤ small_l ≤ big_l (here small_l={small_l} and big_l={big_l})."
+    )]
     RangeNotSatisfied { small_l: usize, big_l: usize },
 }
 
@@ -102,7 +104,7 @@ impl ProofRange {
         big_l: usize,
     ) -> Result<Self, ProofRangeError> {
         if small_l > big_l {
-            return Err(ProofRangeError::RangeNotSatisfied{small_l, big_l});
+            return Err(ProofRangeError::RangeNotSatisfied { small_l, big_l });
         }
         let field = &pvd.parameters.fixed_parameters.field;
         let group = &pvd.parameters.fixed_parameters.group;

--- a/src/eg/src/zk.rs
+++ b/src/eg/src/zk.rs
@@ -21,6 +21,7 @@ use crate::{
     joint_election_public_key::{Ciphertext, Nonce},
     vec1::HasIndexTypeMarker,
 };
+use thiserror::Error;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProofRangeSingle {
@@ -37,6 +38,13 @@ pub type ProofRangeIndex = Index<ProofRange>;
 pub struct ProofRange(Vec<ProofRangeSingle>);
 
 impl HasIndexTypeMarker for ProofRange {}
+
+#[derive(Error, Debug)]
+pub enum ProofRangeError {
+    /// Bla bla
+    #[error("It must be the case that 0 ≤ small_l ≤ big_l (here small_l={small_l} and big_l={big_l}).")]
+    RangeNotSatisfied { small_l: usize, big_l: usize },
+}
 
 impl ProofRange {
     /// This function computes the challenge for the range proof as specified in Equation `46`.
@@ -92,7 +100,10 @@ impl ProofRange {
         nonce: &Nonce,
         small_l: usize,
         big_l: usize,
-    ) -> Self {
+    ) -> Result<Self, ProofRangeError> {
+        if small_l > big_l {
+            return Err(ProofRangeError::RangeNotSatisfied{small_l, big_l});
+        }
         let field = &pvd.parameters.fixed_parameters.field;
         let group = &pvd.parameters.fixed_parameters.group;
 
@@ -133,14 +144,14 @@ impl ProofRange {
             .map(|j| u[j].sub(&c[j].mul(&nonce.xi, field), field))
             .collect::<Vec<FieldElement>>();
 
-        ProofRange(
+        Ok(ProofRange(
             (0..big_l + 1)
                 .map(|j| ProofRangeSingle {
                     c: c[j].clone(),
                     v: v[j].clone(),
                 })
                 .collect(),
-        )
+        ))
     }
 
     /// This function verifies a [`ProofRange`] with respect to a given [`Ciphertext`] and context.

--- a/src/electionguard/Cargo.toml
+++ b/src/electionguard/Cargo.toml
@@ -12,5 +12,4 @@ rand_core = { version = "0.6.4", features = ["getrandom"] }
 eg = { path = "../eg" }
 util = { path = "../util" }
 preencrypted = { path = "../preencrypted" }
-# verifier = { path = "../verifier" }
 chrono = { version = "0.4.34", features = ["serde"] }

--- a/src/electionguard/Cargo.toml
+++ b/src/electionguard/Cargo.toml
@@ -13,3 +13,4 @@ eg = { path = "../eg" }
 util = { path = "../util" }
 preencrypted = { path = "../preencrypted" }
 # verifier = { path = "../verifier" }
+chrono = { version = "0.4.34", features = ["serde"] }

--- a/src/electionguard/src/subcommands/preencrypted_ballot_record.rs
+++ b/src/electionguard/src/subcommands/preencrypted_ballot_record.rs
@@ -144,7 +144,7 @@ impl Subcommand for PreEncryptedBallotRecord {
                     VoterSelection::from_stdioread(&mut stdioread)?
                 };
                 let encrypted_ballot =
-                    regenerated_ballot.finalize(&device, &mut csprng, &voter_ballot);
+                    regenerated_ballot.finalize(&device, &mut csprng, &voter_ballot)?;
 
                 let (mut bx_write, path) = subcommand_helper.artifacts_dir.out_file_stdiowrite(
                     &None,

--- a/src/electionguard/src/subcommands/write_parameters.rs
+++ b/src/electionguard/src/subcommands/write_parameters.rs
@@ -9,6 +9,7 @@ use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 
+use chrono::{DateTime, Utc};
 use eg::{
     election_parameters::ElectionParameters, guardian::GuardianIndex,
     standard_parameters::STANDARD_PARAMETERS, varying_parameters::VaryingParameters,
@@ -48,7 +49,7 @@ pub(crate) struct WriteParameters {
 
     /// Date string.
     #[arg(long)]
-    date: String,
+    date: DateTime<Utc>,
 
     // Jurisdictional information string.
     #[arg(long)]

--- a/src/preencrypted/src/ballot.rs
+++ b/src/preencrypted/src/ballot.rs
@@ -182,7 +182,7 @@ impl BallotPreEncrypted {
         let mut contests = BTreeMap::new();
 
         #[allow(clippy::unwrap_used)] //? TODO: Remove temp development code
-        for i in 1..self.contests.len() + 1{
+        for i in 1..self.contests.len() + 1 {
             let c_idx = ContestIndex::from_one_based_index(i as u32).unwrap();
             let contest = self.contests.get(c_idx).unwrap();
             let correct_content_index = contest.contest_index;
@@ -196,16 +196,18 @@ impl BallotPreEncrypted {
             contests
                 .insert(
                     correct_content_index,
-                    contest.finalize(
-                        device,
-                        csprng,
-                        &voter_ballot.selections.get(c_idx).unwrap().get_vote(),
-                        c.selection_limit,
-                        c.options.len(),
-                    ).map_err(|err|BallotEncryptedError::ProofError{err})?,
+                    contest
+                        .finalize(
+                            device,
+                            csprng,
+                            &voter_ballot.selections.get(c_idx).unwrap().get_vote(),
+                            c.selection_limit,
+                            c.options.len(),
+                        )
+                        .map_err(|err| BallotEncryptedError::ProofError { err })?,
                 )
                 .unwrap();
-        };
+        }
 
         Ok(BallotEncrypted::new(
             self.ballot_style_index,

--- a/src/preencrypted/src/ballot.rs
+++ b/src/preencrypted/src/ballot.rs
@@ -208,6 +208,7 @@ impl BallotPreEncrypted {
         };
 
         Ok(BallotEncrypted::new(
+            self.ballot_style_index,
             &contests,
             BallotState::Cast,
             self.confirmation_code,

--- a/src/preencrypted/src/ballot.rs
+++ b/src/preencrypted/src/ballot.rs
@@ -182,7 +182,7 @@ impl BallotPreEncrypted {
         let mut contests = BTreeMap::new();
 
         #[allow(clippy::unwrap_used)] //? TODO: Remove temp development code
-        for i in 1..self.contests.len() + 1 {
+        for i in 1..=self.contests.len() {
             let c_idx = ContestIndex::from_one_based_index(i as u32).unwrap();
             let contest = self.contests.get(c_idx).unwrap();
             let correct_content_index = contest.contest_index;

--- a/src/preencrypted/src/ballot.rs
+++ b/src/preencrypted/src/ballot.rs
@@ -214,7 +214,7 @@ impl BallotPreEncrypted {
             &contests,
             BallotState::Cast,
             self.confirmation_code,
-            &device.header.parameters.varying_parameters.date,
+            device.header.parameters.varying_parameters.date,
             device.get_uuid(),
         ))
     }

--- a/src/preencrypted/src/ballot.rs
+++ b/src/preencrypted/src/ballot.rs
@@ -200,7 +200,7 @@ impl BallotPreEncrypted {
                         .finalize(
                             device,
                             csprng,
-                            &voter_ballot.selections.get(c_idx).unwrap().get_vote(),
+                            voter_ballot.selections.get(c_idx).unwrap().get_vote(),
                             c.selection_limit,
                             c.options.len(),
                         )

--- a/src/preencrypted/src/ballot.rs
+++ b/src/preencrypted/src/ballot.rs
@@ -199,7 +199,7 @@ impl BallotPreEncrypted {
                     contest.finalize(
                         device,
                         csprng,
-                        &voter_ballot.selections.get(c_idx).unwrap().vote,
+                        &voter_ballot.selections.get(c_idx).unwrap().get_vote(),
                         c.selection_limit,
                         c.options.len(),
                     ),

--- a/src/preencrypted/src/contest.rs
+++ b/src/preencrypted/src/contest.rs
@@ -126,7 +126,11 @@ impl ContestPreEncrypted {
             let selection = self.selections.get(i).unwrap();
             #[allow(clippy::unwrap_used)] //? TODO: Remove temp development code
             proofs
-                .try_push(selection.proof_ballot_correctness(pvd, csprng, i.get_one_based_usize())?)
+                .try_push(selection.proof_ballot_correctness(
+                    pvd,
+                    csprng,
+                    i.get_one_based_usize(),
+                )?)
                 .unwrap();
         }
         Ok(proofs)

--- a/src/preencrypted/src/contest.rs
+++ b/src/preencrypted/src/contest.rs
@@ -135,7 +135,7 @@ impl ContestPreEncrypted {
     pub fn combine_voter_selections(
         &self,
         fixed_parameters: &FixedParameters,
-        voter_selections: &Vec<ContestSelectionPlaintext>,
+        voter_selections: &[ContestSelectionPlaintext],
         selection_limit: usize,
     ) -> Vec<(Ciphertext, Nonce)> {
         assert!(voter_selections.len() + selection_limit == self.selections.len());
@@ -204,7 +204,7 @@ impl ContestPreEncrypted {
         &self,
         device: &Device,
         csprng: &mut Csprng,
-        voter_selections: &Vec<u8>,
+        voter_selections: &[u8],
         selection_limit: usize,
         num_options: usize,
     ) -> ContestEncrypted {

--- a/src/preencrypted/src/contest_selection.rs
+++ b/src/preencrypted/src/contest_selection.rs
@@ -166,7 +166,7 @@ impl ContestSelectionPreEncrypted {
             proofs
                 .try_push(c.0.proof_ballot_correctness(pvd, csprng, sequence_order == i, nonce)?)
                 .unwrap();
-        };
+        }
         Ok(proofs)
     }
 }

--- a/src/preencrypted/src/contest_selection.rs
+++ b/src/preencrypted/src/contest_selection.rs
@@ -13,7 +13,7 @@ use eg::{
     index::Index,
     joint_election_public_key::{Ciphertext, Nonce},
     vec1::Vec1,
-    zk::ProofRange,
+    zk::{ProofRange, ProofRangeError},
 };
 
 use serde::{Deserialize, Serialize};
@@ -156,17 +156,17 @@ impl ContestSelectionPreEncrypted {
         pvd: &PreVotingData,
         csprng: &mut Csprng,
         sequence_order: usize,
-    ) -> Vec1<ProofRange> {
+    ) -> Result<Vec1<ProofRange>, ProofRangeError> {
         let mut proofs = Vec1::new();
         // for (i, selection) in self.selections.iter().enumerate() {
-        self.selections.iter().enumerate().for_each(|(i, c)| {
+        for (i, c) in self.selections.iter().enumerate() {
             #[allow(clippy::unwrap_used)] //? TODO: Remove temp development code
             let nonce = c.1.as_ref().unwrap();
             #[allow(clippy::unwrap_used)] //? TODO: Remove temp development code
             proofs
-                .try_push(c.0.proof_ballot_correctness(pvd, csprng, sequence_order == i, nonce))
+                .try_push(c.0.proof_ballot_correctness(pvd, csprng, sequence_order == i, nonce)?)
                 .unwrap();
-        });
-        proofs
+        };
+        Ok(proofs)
     }
 }


### PR DESCRIPTION
## Purpose

To clean up code in the `eg` crate, including:
* Make ElectionRecord up to date with specification
* Remove commented out code
* Fix "temporary development code".

## Changes

* Prover functions now returns `Result`s with proper errors instead of panicking. 
* Commented out code removed
* ElectionRecord updated
* "Temporary development code" fixed

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
