### PR TITLE
Use libcrux for HMAC

### DIFF
--- a/src/eg/Cargo.toml
+++ b/src/eg/Cargo.toml
@@ -6,7 +6,6 @@ publish = false
 
 [dependencies]
 digest = "0.10"
-hmac = "0.12"
 itertools = "0.12"
 lazy_static = "1.4"
 num-bigint = "0.4"
@@ -18,6 +17,7 @@ static_assertions = "1.1.0"
 thiserror = "1.0"
 util = { path = "../util" }
 base64 = "0.21.2"
+libcrux = "0.0.2-pre.2"
 
 # For testing
 anyhow = "1.0"


### PR DESCRIPTION
## Purpose

Use implementation of HMAC from [libcrux](https://github.com/cryspen/libcrux), as discussed with @tschudid.

## Changes

Substitute libcrux HMAC with HMAC from hmac crate.

## Checklist

- [ ] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
